### PR TITLE
feat(docker): rotate logs

### DIFF
--- a/docker-compose.portal.yml
+++ b/docker-compose.portal.yml
@@ -1,5 +1,13 @@
 ---
 version: "3.5"
+
+x-logging:
+  &default-logging
+  driver: "json-file"
+  options:
+    max-size: "100m"
+    max-file: "5"
+
 services:
   # global prometheus instance scraping data from the local instances
   portal_prometheus:
@@ -9,6 +17,8 @@ services:
       portal:
         aliases:
           - prometheus
+    logging:
+      *default-logging
     expose:
       - "9090"
     ports:
@@ -20,6 +30,8 @@ services:
     container_name: portal_influxdb
     networks:
       - portal
+    logging:
+      *default-logging
     environment:
       - INFLUXDB_GRAPHITE_ENABLED
       - INFLUXDB_REPORTING_DISABLED
@@ -47,6 +59,8 @@ services:
     container_name: portal_grafana
     depends_on:
       - portal_prometheus
+    logging:
+      *default-logging
     networks:
       - portal
     environment:
@@ -63,6 +77,8 @@ services:
     restart: always
     networks:
       - portal
+    logging:
+      *default-logging
     healthcheck:
       test: wget http://localhost/ping -qO /dev/null || return 1
       interval: 2m

--- a/docker-compose.site.yml
+++ b/docker-compose.site.yml
@@ -2,12 +2,22 @@
 # openstack instance
 ---
 version: "3.5"
+
+x-logging:
+  &default-logging
+  driver: "json-file"
+  options:
+    max-size: "100m"
+    max-file: "5"
+
 services:
   site_exporter:
     image: "denbicloud/os_project_usage_exporter:${EXPORTER_TAG}"
     container_name: project_usage_exporter
     networks:
       - usage_exporter
+    logging:
+      *default-logging
     environment:
       - USAGE_EXPORTER_START_DATE
       - USAGE_EXPORTER_UPDATE_INTERVAL
@@ -31,6 +41,8 @@ services:
     # use self build Dockerfile as alternative
     # build: prod/site_prometheus
     container_name: project_usage_prometheus
+    logging:
+      *default-logging
     networks:
       usage_exporter:
         aliases:
@@ -45,6 +57,8 @@ services:
     # use self build Dockerfile as alternative
     # build: prod/haproxy
     container_name: project_usage_proxy
+    logging:
+      *default-logging
     networks:
       - usage_exporter
     expose:
@@ -63,6 +77,8 @@ services:
     # use self build Dockerfile as alternative
     # build: prod/grafana
     container_name: project_usage_grafana
+    logging:
+      *default-logging
     depends_on:
       - site_prometheus
     networks:


### PR DESCRIPTION
@tensulin 
Portal and Site (for dev only for site-a, not for site-b, site-c etc.) services now rotate logs. Maximum of 5 log files a 100 mb.