### PR TITLE
fix(docker): timescaledb version needs update

### DIFF
--- a/docker-compose.portal.yml
+++ b/docker-compose.portal.yml
@@ -23,7 +23,7 @@ services:
       - "9090"
 
   portal_timescaledb:
-    image: "timescale/timescaledb-ha:pg14.3-ts2.7.0-latest"
+    image: "timescale/timescaledb-ha:pg14.4-ts2.7.2-latest"
     container_name: portal_timescaledb
     command: postgres -c shared_preload_libraries=timescaledb
     networks:


### PR DESCRIPTION
@vktrrdk 
Timescaledb version needs update, otherwise promscale will not start.